### PR TITLE
Add a link to instructions for creating userChrome.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,6 @@ Incompatibilities between different files can happen. There's not much we can do
 
 The master branch should always track Nightly. When a version merges into beta, a new branch is created for this specific Firefox version. If any code is broken on this branch, it is possible to cherry-pick the necessary commits without pulling other broken code in.
 
+To use new CSS, you'll need to [create `userChrome.css` for your copy of Firefox](http://kb.mozillazine.org/index.php?title=UserChrome.css&printable=yes#Creating) if you don't already have one, then paste these tweaks inside.
+
 If you wish to contribute to this repository, please read `CONTRIBUTING.md`.


### PR DESCRIPTION
The README described how the repo should be used, but not how to use the tweaks. This adds a link to the mozillaZine knowledgebase article about creating `userChrome.css`.